### PR TITLE
proto: add localhost UDP cue receptor

### DIFF
--- a/.codeagent-outcome-ringserver-seedlink-udp.md
+++ b/.codeagent-outcome-ringserver-seedlink-udp.md
@@ -1,0 +1,79 @@
+# Ringserver UDP-cue receptor outcome
+
+## Result
+
+Implemented a localhost-only Binary Canticle UDP-cue receptor with a closed,
+bounded canonical envelope, Ed25519 verification, issuer/key quarantine
+policy, timestamp/TTL checks, persistent replay deduplication, subject
+tombstones, content-free typed receipts, and a private DataLink publisher
+seam. The custom datagram protocol is not described as SeedLink.
+
+Native verdict: EarthScope Ringserver 4.5.4 is TCP-only for DataLink,
+SeedLink, and HTTP/WebSocket. It has no native UDP submission path. Exact
+tagged sources and FDSN documentation are cited in `PROTOTYPE-NOTES.md`.
+
+## Commands and evidence
+
+Commands actually run:
+
+```text
+git status --short --branch
+python3 --version
+openssl version
+command -v ringserver ringserverctl dlclient slinktool
+python3 -m unittest discover -s tests -v
+python3 -m compileall -q canticle_receptor tests
+git diff --check
+```
+
+Environment evidence:
+
+```text
+Python 3.14.6
+OpenSSL 3.6.3
+cryptography 49.0.0
+nacl 1.6.2
+ringserver, ringserverctl, dlclient, slinktool: missing
+```
+
+Focused result: **15 tests passed**. Coverage includes deterministic encoding,
+valid acceptance,
+invalid signatures, invalid/future/expired timestamps, excessive TTL, replay,
+tombstones, oversized/malformed/non-canonical packets, forbidden fields,
+issuer/key/cache/publisher quarantine paths, private publisher handoff,
+loopback UDP handoff, non-loopback bind refusal, and replay rejection after
+closing and reopening the SQLite state.
+
+## Files changed
+
+```text
+PROTOTYPE-NOTES.md
+.codeagent-outcome-ringserver-seedlink-udp.md
+pyproject.toml
+canticle_receptor/__init__.py
+canticle_receptor/__main__.py
+canticle_receptor/_publisher.py
+canticle_receptor/codec.py
+canticle_receptor/model.py
+canticle_receptor/receptor.py
+canticle_receptor/state.py
+canticle_receptor/udp.py
+tests/test_receptor.py
+tests/test_udp.py
+```
+
+Silas's memo was not edited. Ringserver core was not fetched into or modified
+in this worktree.
+
+## Limitations and exact next proof
+
+No Ringserver flow was claimed because the required server and DataLink
+client executables are absent. The current CLI uses a receipt-only test
+publisher; the private publisher protocol is tested with a recording adapter.
+The state transition is an at-most-once handoff attempt, not an exactly-once
+or delivery guarantee.
+
+Provision EarthScope Ringserver 4.5.4, `dalitool`, and `simpledali` 0.8.3,
+then run the loopback-restricted volatile server, metadata-only reader, and
+single JSON writer commands in `PROTOTYPE-NOTES.md`. Completion requires the
+reader to observe `BC_CUE/JSON`; any ring packet ID is only a local cursor.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/.lane-workorder-ringserver-seedlink-udp.md
+++ b/.lane-workorder-ringserver-seedlink-udp.md
@@ -1,0 +1,28 @@
+# Ringserver UDP-cue receptor prototype — implementation workorder
+
+## Goal
+Build a runnable, tested **Binary Canticle sidecar prototype** in this worktree. It must determine the native Ringserver/DataLink UDP verdict first, then implement the smallest honest UDP-cue receptor plus a narrow private DataLink-publisher adapter seam. This is a prototype, not a Ringserver fork or a replacement for its TCP/FIFO replay behavior.
+
+## Scope / acceptance
+1. Record an evidence-based native verdict: whether upstream Ringserver / SeedLink / DataLink natively accepts UDP for this use. Cite exact inspected source/docs/version in a short `PROTOTYPE-NOTES.md`. Do not call the custom datagram protocol standard SeedLink.
+2. Implement only a bounded notice envelope and local receptor:
+   - deterministic/canonical encoding and a bounded maximum packet/notice size;
+   - signature verification (use a real local cryptographic primitive available in the environment; if unavailable, fail closed and document the dependency rather than inventing security);
+   - issuer/key policy, issued/expiry timestamps/TTL, replay identity, replay cache, tombstones;
+   - explicit typed `accept`, `reject`, and `quarantine` receipts, with reasons that never echo sensitive payload contents;
+   - notices must never carry raw Tier-1 objects, filesystem paths, bearer values, download/retrieval routes, or transcripts.
+3. Provide a UDP-cue receiver/listener that takes only the constrained envelope and hands an accepted verified notice to a narrow **private DataLink publisher interface**. The interface must be testable without Ringserver.
+4. If Ringserver tools can be installed/started without mutating Ringserver core, prove a localhost-only ephemeral writer/reader flow. Otherwise implement and test the adapter interface, and name the missing Ringserver runtime dependency and exact command/config needed for the later proof.
+5. Test normal acceptance, invalid signature, expiry/TTL, replay and tombstone, oversized/malformed notice, quarantine behavior, and the adapter/receptor handoff. Include a restart/replay-dedup proof.
+6. Keep a concise outcome journal: `.codeagent-outcome-ringserver-seedlink-udp.md`, including commands actually run, test evidence, native-UDP verdict, files changed, limitations, and exact next proof.
+
+## Non-negotiable boundaries
+- Work only in this isolated worktree. Do **not** edit Ringserver core.
+- No git commit, push, PR, GitHub issue/comment, CI dispatch, deploy, restart, config/database mutation, auth workaround, secret access, or remote credential use.
+- Do not rewrite Silas's research memo; turn its boundary into code and tests.
+- Do not implement raw-object replication, artifact fetch, graph mutation/promotion, remote listener/proxy trust, FEC, or general delivery guarantees.
+- A ring packet ID/offset, if encountered, is a local cursor only—not provenance, receipt, identity, or exactly-once proof.
+- Do not expose notice contents in errors, diagnostics, test output, logs, or receipts.
+
+## Completion behavior
+Before declaring done, inspect the worktree diff and run the focused tests. Stop and journal any concrete environmental blocker rather than broadening scope. Leave the worktree intact for independent review by Silas.

--- a/PROTOTYPE-NOTES.md
+++ b/PROTOTYPE-NOTES.md
@@ -1,0 +1,131 @@
+# UDP-cue receptor prototype notes
+
+## Native verdict
+
+**Ringserver does not natively accept UDP cues.** This verdict is based on
+EarthScope Ringserver **4.5.4**, tag `v4.5.4`, commit
+[`2df558c`](https://github.com/EarthScope/ringserver/commit/2df558cdb480489dcdddf740ae8724076db20db3),
+inspected 2026-07-25:
+
+- The tagged
+  [`README.md:3-5`](https://github.com/EarthScope/ringserver/blob/v4.5.4/README.md#L3-L5)
+  says all supported protocols are TCP-based. Its
+  [`README.md:73-75`](https://github.com/EarthScope/ringserver/blob/v4.5.4/README.md#L73-L75)
+  names only TCP DataLink and the local miniSEED filesystem scanner as packet
+  submission mechanisms.
+- The tagged protocol enum contains only DataLink, SeedLink, and HTTP
+  ([`src/ringserver.h:36-44`](https://github.com/EarthScope/ringserver/blob/v4.5.4/src/ringserver.h#L36-L44)).
+  The sole listener initializer sets `SOCK_STREAM` and calls `listen(2)`
+  ([`src/config.c:2634-2719`](https://github.com/EarthScope/ringserver/blob/v4.5.4/src/config.c#L2634-L2719)).
+- The tagged manual explicitly states that all communications use TCP and
+  DataLink is the submission protocol
+  ([`doc/ringserver.md:26-33`](https://github.com/EarthScope/ringserver/blob/v4.5.4/doc/ringserver.md#L26-L33)).
+- The authoritative FDSN
+  [SeedLink v4 protocol](https://docs.fdsn.org/projects/seedlink/en/latest/protocol.html)
+  says SeedLink communication and sessions use TCP/IP connections.
+
+Therefore this package implements a **custom Binary Canticle UDP cue**, not
+standard SeedLink. Ringserver remains an unmodified, downstream TCP DataLink
+target behind a private publisher interface.
+
+## Implemented boundary
+
+The datagram is canonical JSON with a hard 1,200-byte packet limit and a
+512-byte notice-object limit. The schema is closed:
+
+```text
+version, issuer, key_id, signature,
+notice: kind, subject, notice_id, issued_at, expires_at
+```
+
+`subject` must be a lowercase `sha256:` digest; no arbitrary payload field
+exists. As a result, notices cannot represent raw Tier-1 objects, filesystem
+paths, bearer values, retrieval routes, transcripts, graph mutations, or
+artifact data. Unknown or extra fields are rejected.
+
+Ed25519 signs the canonical unsigned envelope using `cryptography>=45`.
+Missing cryptographic support prevents package startup; there is no insecure
+fallback. Active issuer/key policy, a 60-second maximum TTL, five seconds of
+future clock skew, persistent bounded replay claims, and persistent subject
+tombstones are enforced before the private publisher handoff.
+
+Receipts are typed `accept`, `reject`, or `quarantine` values with closed
+reason enums and no notice data. The UDP listener can bind only an IPv4
+loopback address. Replay claims are persisted before publication, so the seam
+is an at-most-once publication *attempt*: publisher failure is quarantined and
+is not retried under the same replay identity. This is deliberately not a
+delivery or exactly-once guarantee.
+
+Run the focused tests:
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+Run the local receptor in receipt-only adapter-test mode:
+
+```bash
+python3 -m canticle_receptor \
+  --issuer issuer-a \
+  --key-id key-a \
+  --public-key-hex <64-hex-character-ed25519-public-key> \
+  --state ./receptor-state.sqlite3 \
+  --host 127.0.0.1 \
+  --port 9999
+```
+
+The CLI's receipt-only publisher proves receptor operation but does not claim
+DataLink publication. A production adapter must implement the private
+`DataLinkPublisher.publish(VerifiedNotice)` seam.
+
+## Native runtime proof status
+
+The environment has no `ringserver`, `dalitool`, `slinktool`, or `dlclient`
+binary, so no honest Ringserver writer/reader proof was run. The missing
+runtime dependencies are EarthScope Ringserver 4.5.4 and a DataLink client
+capable of both writing and reading (for example `simpledali` 0.8.3 plus
+`dalitool`).
+
+Once those binaries are provisioned, the exact next proof is:
+
+```bash
+proof_dir="$(mktemp -d)"
+mkdir "$proof_dir/ring"
+RS_ACCEPT_IP=127.0.0.1/32 \
+RS_WRITE_IP=127.0.0.1/32 \
+RS_TRUSTED_IP=127.0.0.1/32 \
+ringserver -Rd "$proof_dir/ring" -Rs 1M -Rp 1200 -VOLATILE -DL 16000
+```
+
+In a second shell, start a metadata-only reader:
+
+```bash
+dalitool -p -m '^BC_CUE/JSON$' 127.0.0.1:16000
+```
+
+Then write one non-sensitive JSON smoke packet using the official
+`simpledali` socket API:
+
+```bash
+python3 -m venv "$proof_dir/venv"
+"$proof_dir/venv/bin/pip" install simpledali==0.8.3
+"$proof_dir/venv/bin/python" - <<'PY'
+import asyncio
+import simpledali
+
+async def main():
+    async with simpledali.SocketDataLink("127.0.0.1", 16000) as dali:
+        await dali.id("canticle-smoke", "local", 0, "python")
+        now = simpledali.datetimeToHPTime(simpledali.utcnowWithTz())
+        result = await dali.writeJSON(
+            "BC_CUE/JSON", now, now, {"kind": "adapter-smoke", "version": 1}
+        )
+        if result.type != "OK":
+            raise RuntimeError("DataLink write failed")
+
+asyncio.run(main())
+PY
+```
+
+The proof is complete only when `dalitool` observes the `BC_CUE/JSON` packet.
+Its ring packet ID is treated solely as a local cursor.

--- a/canticle_receptor/__init__.py
+++ b/canticle_receptor/__init__.py
@@ -1,0 +1,30 @@
+"""Bounded Binary Canticle UDP-cue receptor."""
+
+from .codec import MAX_NOTICE_SIZE, MAX_PACKET_SIZE, encode_signed_notice
+from .model import (
+    AcceptReceipt,
+    Notice,
+    NoticeKind,
+    QuarantineReceipt,
+    RejectReceipt,
+    VerifiedNotice,
+)
+from .receptor import IssuerPolicy, NoticeReceptor
+from .state import ReceptorState
+from .udp import UdpCueListener
+
+__all__ = [
+    "MAX_NOTICE_SIZE",
+    "MAX_PACKET_SIZE",
+    "AcceptReceipt",
+    "IssuerPolicy",
+    "Notice",
+    "NoticeKind",
+    "NoticeReceptor",
+    "QuarantineReceipt",
+    "ReceptorState",
+    "RejectReceipt",
+    "UdpCueListener",
+    "VerifiedNotice",
+    "encode_signed_notice",
+]

--- a/canticle_receptor/__main__.py
+++ b/canticle_receptor/__main__.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from .model import VerifiedNotice
+from .receptor import IssuerPolicy, NoticeReceptor
+from .state import ReceptorState
+from .udp import UdpCueListener
+
+
+class _ReceiptOnlyPublisher:
+    def publish(self, notice: VerifiedNotice) -> None:
+        del notice
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the localhost Binary Canticle UDP-cue receptor prototype."
+    )
+    parser.add_argument("--issuer", required=True)
+    parser.add_argument("--key-id", required=True)
+    parser.add_argument("--public-key-hex", required=True)
+    parser.add_argument("--state", required=True)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9999)
+    parser.add_argument("--once", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(
+            bytes.fromhex(args.public_key_hex)
+        )
+    except ValueError:
+        print("invalid public key", file=sys.stderr)
+        return 2
+
+    state = ReceptorState(args.state)
+    receptor = NoticeReceptor(
+        issuers={
+            args.issuer: IssuerPolicy(keys={args.key_id: public_key}),
+        },
+        state=state,
+        publisher=_ReceiptOnlyPublisher(),
+    )
+    try:
+        with UdpCueListener(receptor, host=args.host, port=args.port) as listener:
+            if args.once:
+                receipt = listener.receive_once()
+                print(receipt.decision, receipt.reason)
+            else:
+                listener.serve_forever(
+                    on_receipt=lambda receipt: print(
+                        receipt.decision,
+                        receipt.reason,
+                        flush=True,
+                    )
+                )
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        state.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/canticle_receptor/_publisher.py
+++ b/canticle_receptor/_publisher.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from .model import VerifiedNotice
+
+
+class PublisherUnavailable(Exception):
+    """The private publisher could not accept a verified notice."""
+
+
+class DataLinkPublisher(Protocol):
+    """Private adapter seam; implementations own the DataLink TCP details."""
+
+    def publish(self, notice: VerifiedNotice) -> None:
+        """Accept one already verified, constrained notice for publication."""

--- a/canticle_receptor/codec.py
+++ b/canticle_receptor/codec.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from .model import Notice, NoticeKind, RejectReason
+
+MAX_PACKET_SIZE = 1200
+MAX_NOTICE_SIZE = 512
+PROTOCOL_VERSION = 1
+
+_IDENTIFIER = re.compile(r"[a-z][a-z0-9.-]{0,62}\Z")
+_NOTICE_ID = re.compile(r"[0-9a-f]{32}\Z")
+_SUBJECT = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_TOP_LEVEL_FIELDS = frozenset({"version", "issuer", "key_id", "notice", "signature"})
+_NOTICE_FIELDS = frozenset({"kind", "subject", "notice_id", "issued_at", "expires_at"})
+
+
+class EnvelopeError(ValueError):
+    def __init__(self, reason: RejectReason):
+        super().__init__(reason.value)
+        self.reason = reason
+
+
+class _DuplicateField(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedEnvelope:
+    issuer: str
+    key_id: str
+    notice: Notice
+    signature: bytes
+    signed_bytes: bytes
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+
+
+def _object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateField
+        result[key] = value
+    return result
+
+
+def _reject_constant(_: str) -> None:
+    raise ValueError
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(value: str) -> bytes:
+    if not re.fullmatch(r"[A-Za-z0-9_-]{86}", value):
+        raise EnvelopeError(RejectReason.MALFORMED_PACKET)
+    try:
+        decoded = base64.b64decode(value + "==", altchars=b"-_", validate=True)
+    except (binascii.Error, ValueError) as error:
+        raise EnvelopeError(RejectReason.MALFORMED_PACKET) from error
+    if len(decoded) != 64 or _b64url_encode(decoded) != value:
+        raise EnvelopeError(RejectReason.MALFORMED_PACKET)
+    return decoded
+
+
+def _notice_dict(notice: Notice) -> dict[str, object]:
+    return {
+        "expires_at": notice.expires_at,
+        "issued_at": notice.issued_at,
+        "kind": notice.kind.value,
+        "notice_id": notice.notice_id,
+        "subject": notice.subject,
+    }
+
+
+def _unsigned_dict(issuer: str, key_id: str, notice: Notice) -> dict[str, object]:
+    return {
+        "issuer": issuer,
+        "key_id": key_id,
+        "notice": _notice_dict(notice),
+        "version": PROTOCOL_VERSION,
+    }
+
+
+def encode_signed_notice(
+    private_key: Ed25519PrivateKey,
+    *,
+    issuer: str,
+    key_id: str,
+    notice: Notice,
+) -> bytes:
+    unsigned = _unsigned_dict(issuer, key_id, notice)
+    signed_bytes = canonical_json(unsigned)
+    envelope = dict(unsigned)
+    envelope["signature"] = _b64url_encode(private_key.sign(signed_bytes))
+    packet = canonical_json(envelope)
+    if len(canonical_json(_notice_dict(notice))) > MAX_NOTICE_SIZE:
+        raise ValueError("notice_too_large")
+    if len(packet) > MAX_PACKET_SIZE:
+        raise ValueError("packet_too_large")
+    return packet
+
+
+def parse_packet(packet: bytes) -> ParsedEnvelope:
+    if len(packet) > MAX_PACKET_SIZE:
+        raise EnvelopeError(RejectReason.PACKET_TOO_LARGE)
+
+    try:
+        text = packet.decode("utf-8", errors="strict")
+        value = json.loads(
+            text,
+            object_pairs_hook=_object_without_duplicates,
+            parse_constant=_reject_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateField, ValueError) as error:
+        raise EnvelopeError(RejectReason.MALFORMED_PACKET) from error
+
+    if not isinstance(value, dict) or canonical_json(value) != packet:
+        raise EnvelopeError(RejectReason.NON_CANONICAL_PACKET)
+    if set(value) != _TOP_LEVEL_FIELDS:
+        raise EnvelopeError(RejectReason.MALFORMED_PACKET)
+    if type(value["version"]) is not int or value["version"] != PROTOCOL_VERSION:
+        raise EnvelopeError(RejectReason.MALFORMED_PACKET)
+
+    issuer = value["issuer"]
+    key_id = value["key_id"]
+    raw_notice = value["notice"]
+    signature_text = value["signature"]
+    if (
+        not isinstance(issuer, str)
+        or _IDENTIFIER.fullmatch(issuer) is None
+        or not isinstance(key_id, str)
+        or _IDENTIFIER.fullmatch(key_id) is None
+        or not isinstance(raw_notice, dict)
+        or not isinstance(signature_text, str)
+    ):
+        raise EnvelopeError(RejectReason.MALFORMED_PACKET)
+    if set(raw_notice) != _NOTICE_FIELDS:
+        raise EnvelopeError(RejectReason.MALFORMED_PACKET)
+    if len(canonical_json(raw_notice)) > MAX_NOTICE_SIZE:
+        raise EnvelopeError(RejectReason.PACKET_TOO_LARGE)
+
+    kind = raw_notice["kind"]
+    subject = raw_notice["subject"]
+    notice_id = raw_notice["notice_id"]
+    issued_at = raw_notice["issued_at"]
+    expires_at = raw_notice["expires_at"]
+    if (
+        not isinstance(kind, str)
+        or kind not in {member.value for member in NoticeKind}
+        or not isinstance(subject, str)
+        or _SUBJECT.fullmatch(subject) is None
+        or not isinstance(notice_id, str)
+        or _NOTICE_ID.fullmatch(notice_id) is None
+        or type(issued_at) is not int
+        or type(expires_at) is not int
+        or issued_at < 0
+        or expires_at < 0
+        or issued_at > 2**63 - 1
+        or expires_at > 2**63 - 1
+    ):
+        raise EnvelopeError(RejectReason.MALFORMED_PACKET)
+
+    notice = Notice(
+        kind=NoticeKind(kind),
+        subject=subject,
+        notice_id=notice_id,
+        issued_at=issued_at,
+        expires_at=expires_at,
+    )
+    unsigned = _unsigned_dict(issuer, key_id, notice)
+    return ParsedEnvelope(
+        issuer=issuer,
+        key_id=key_id,
+        notice=notice,
+        signature=_b64url_decode(signature_text),
+        signed_bytes=canonical_json(unsigned),
+    )

--- a/canticle_receptor/model.py
+++ b/canticle_receptor/model.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Literal, TypeAlias
+
+
+class NoticeKind(StrEnum):
+    AVAILABLE = "available"
+    TOMBSTONE = "tombstone"
+
+
+@dataclass(frozen=True, slots=True)
+class Notice:
+    kind: NoticeKind
+    subject: str
+    notice_id: str
+    issued_at: int
+    expires_at: int
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedNotice:
+    issuer: str
+    key_id: str
+    notice: Notice
+
+
+class RejectReason(StrEnum):
+    PACKET_TOO_LARGE = "packet_too_large"
+    MALFORMED_PACKET = "malformed_packet"
+    NON_CANONICAL_PACKET = "non_canonical_packet"
+    INVALID_SIGNATURE = "invalid_signature"
+    INVALID_TIMESTAMP = "invalid_timestamp"
+    TTL_EXCEEDED = "ttl_exceeded"
+    NOT_YET_VALID = "not_yet_valid"
+    EXPIRED = "expired"
+    REPLAY = "replay"
+    SUBJECT_TOMBSTONED = "subject_tombstoned"
+
+
+class QuarantineReason(StrEnum):
+    ISSUER_NOT_ALLOWED = "issuer_not_allowed"
+    ISSUER_QUARANTINED = "issuer_quarantined"
+    KEY_NOT_ALLOWED = "key_not_allowed"
+    REPLAY_CACHE_FULL = "replay_cache_full"
+    TOMBSTONE_CACHE_FULL = "tombstone_cache_full"
+    PUBLISHER_UNAVAILABLE = "publisher_unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptReceipt:
+    decision: Literal["accept"] = field(default="accept", init=False)
+    reason: Literal["accepted"] = field(default="accepted", init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class RejectReceipt:
+    reason: RejectReason
+    decision: Literal["reject"] = field(default="reject", init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class QuarantineReceipt:
+    reason: QuarantineReason
+    decision: Literal["quarantine"] = field(default="quarantine", init=False)
+
+
+Receipt: TypeAlias = AcceptReceipt | RejectReceipt | QuarantineReceipt

--- a/canticle_receptor/receptor.py
+++ b/canticle_receptor/receptor.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from ._publisher import DataLinkPublisher, PublisherUnavailable
+from .codec import EnvelopeError, parse_packet
+from .model import (
+    AcceptReceipt,
+    QuarantineReason,
+    QuarantineReceipt,
+    Receipt,
+    RejectReason,
+    RejectReceipt,
+    VerifiedNotice,
+)
+from .state import ClaimOutcome, ReceptorState
+
+MAX_TTL_SECONDS = 60
+MAX_FUTURE_SKEW_SECONDS = 5
+
+
+@dataclass(frozen=True, slots=True)
+class IssuerPolicy:
+    keys: Mapping[str, Ed25519PublicKey]
+    quarantined: bool = False
+
+
+class NoticeReceptor:
+    def __init__(
+        self,
+        *,
+        issuers: Mapping[str, IssuerPolicy],
+        state: ReceptorState,
+        publisher: DataLinkPublisher,
+        clock: Callable[[], float] = time.time,
+    ):
+        self._issuers = dict(issuers)
+        self._state = state
+        self._publisher = publisher
+        self._clock = clock
+
+    def process(self, packet: bytes) -> Receipt:
+        try:
+            envelope = parse_packet(packet)
+        except EnvelopeError as error:
+            return RejectReceipt(error.reason)
+
+        issuer_policy = self._issuers.get(envelope.issuer)
+        if issuer_policy is None:
+            return QuarantineReceipt(QuarantineReason.ISSUER_NOT_ALLOWED)
+        if issuer_policy.quarantined:
+            return QuarantineReceipt(QuarantineReason.ISSUER_QUARANTINED)
+        public_key = issuer_policy.keys.get(envelope.key_id)
+        if public_key is None:
+            return QuarantineReceipt(QuarantineReason.KEY_NOT_ALLOWED)
+        try:
+            public_key.verify(envelope.signature, envelope.signed_bytes)
+        except InvalidSignature:
+            return RejectReceipt(RejectReason.INVALID_SIGNATURE)
+
+        now = int(self._clock())
+        notice = envelope.notice
+        if notice.expires_at <= notice.issued_at:
+            return RejectReceipt(RejectReason.INVALID_TIMESTAMP)
+        if notice.expires_at - notice.issued_at > MAX_TTL_SECONDS:
+            return RejectReceipt(RejectReason.TTL_EXCEEDED)
+        if notice.issued_at > now + MAX_FUTURE_SKEW_SECONDS:
+            return RejectReceipt(RejectReason.NOT_YET_VALID)
+        if notice.expires_at <= now:
+            return RejectReceipt(RejectReason.EXPIRED)
+
+        claim = self._state.claim(notice, now)
+        if claim is ClaimOutcome.REPLAY:
+            return RejectReceipt(RejectReason.REPLAY)
+        if claim is ClaimOutcome.SUBJECT_TOMBSTONED:
+            return RejectReceipt(RejectReason.SUBJECT_TOMBSTONED)
+        if claim is ClaimOutcome.REPLAY_CACHE_FULL:
+            return QuarantineReceipt(QuarantineReason.REPLAY_CACHE_FULL)
+        if claim is ClaimOutcome.TOMBSTONE_CACHE_FULL:
+            return QuarantineReceipt(QuarantineReason.TOMBSTONE_CACHE_FULL)
+
+        verified = VerifiedNotice(
+            issuer=envelope.issuer,
+            key_id=envelope.key_id,
+            notice=notice,
+        )
+        try:
+            self._publisher.publish(verified)
+        except PublisherUnavailable:
+            return QuarantineReceipt(QuarantineReason.PUBLISHER_UNAVAILABLE)
+        return AcceptReceipt()

--- a/canticle_receptor/state.py
+++ b/canticle_receptor/state.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import sqlite3
+from enum import StrEnum
+from pathlib import Path
+
+from .model import Notice, NoticeKind
+
+
+class ClaimOutcome(StrEnum):
+    CLAIMED = "claimed"
+    REPLAY = "replay"
+    SUBJECT_TOMBSTONED = "subject_tombstoned"
+    REPLAY_CACHE_FULL = "replay_cache_full"
+    TOMBSTONE_CACHE_FULL = "tombstone_cache_full"
+
+
+class ReceptorState:
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        max_replay_entries: int = 10_000,
+        max_tombstones: int = 10_000,
+        replay_retention_seconds: int = 86_400,
+    ):
+        if max_replay_entries < 1 or max_tombstones < 1 or replay_retention_seconds < 0:
+            raise ValueError("invalid_state_bounds")
+        self._max_replay_entries = max_replay_entries
+        self._max_tombstones = max_tombstones
+        self._replay_retention_seconds = replay_retention_seconds
+        self._connection = sqlite3.connect(path)
+        self._connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS seen_notices (
+                notice_id TEXT PRIMARY KEY,
+                retain_until INTEGER NOT NULL
+            )
+            """
+        )
+        self._connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS subject_tombstones (
+                subject TEXT PRIMARY KEY,
+                notice_id TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        self._connection.commit()
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def claim(self, notice: Notice, now: int) -> ClaimOutcome:
+        try:
+            self._connection.execute("BEGIN IMMEDIATE")
+            self._connection.execute(
+                "DELETE FROM seen_notices WHERE retain_until <= ?",
+                (now,),
+            )
+            if self._connection.execute(
+                "SELECT 1 FROM seen_notices WHERE notice_id = ?",
+                (notice.notice_id,),
+            ).fetchone():
+                self._connection.rollback()
+                return ClaimOutcome.REPLAY
+            if self._connection.execute(
+                "SELECT 1 FROM subject_tombstones WHERE subject = ?",
+                (notice.subject,),
+            ).fetchone():
+                self._connection.rollback()
+                return ClaimOutcome.SUBJECT_TOMBSTONED
+
+            seen_count = self._connection.execute(
+                "SELECT COUNT(*) FROM seen_notices"
+            ).fetchone()[0]
+            if seen_count >= self._max_replay_entries:
+                self._connection.rollback()
+                return ClaimOutcome.REPLAY_CACHE_FULL
+
+            if notice.kind is NoticeKind.TOMBSTONE:
+                tombstone_count = self._connection.execute(
+                    "SELECT COUNT(*) FROM subject_tombstones"
+                ).fetchone()[0]
+                if tombstone_count >= self._max_tombstones:
+                    self._connection.rollback()
+                    return ClaimOutcome.TOMBSTONE_CACHE_FULL
+                self._connection.execute(
+                    """
+                    INSERT INTO subject_tombstones (subject, notice_id, created_at)
+                    VALUES (?, ?, ?)
+                    """,
+                    (notice.subject, notice.notice_id, now),
+                )
+
+            self._connection.execute(
+                "INSERT INTO seen_notices (notice_id, retain_until) VALUES (?, ?)",
+                (
+                    notice.notice_id,
+                    notice.expires_at + self._replay_retention_seconds,
+                ),
+            )
+            self._connection.commit()
+            return ClaimOutcome.CLAIMED
+        except sqlite3.Error:
+            self._connection.rollback()
+            raise

--- a/canticle_receptor/udp.py
+++ b/canticle_receptor/udp.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import ipaddress
+import socket
+from collections.abc import Callable
+
+from .codec import MAX_PACKET_SIZE
+from .model import Receipt
+from .receptor import NoticeReceptor
+
+
+class UdpCueListener:
+    def __init__(
+        self,
+        receptor: NoticeReceptor,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 9999,
+    ):
+        address = ipaddress.ip_address(host)
+        if address.version != 4 or not address.is_loopback:
+            raise ValueError("listener_must_be_ipv4_loopback")
+        self._receptor = receptor
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._socket.bind((host, port))
+
+    @property
+    def address(self) -> tuple[str, int]:
+        host, port = self._socket.getsockname()
+        return str(host), int(port)
+
+    def close(self) -> None:
+        self._socket.close()
+
+    def __enter__(self) -> UdpCueListener:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def receive_once(self, *, timeout: float | None = None) -> Receipt:
+        self._socket.settimeout(timeout)
+        packet, _peer = self._socket.recvfrom(MAX_PACKET_SIZE + 1)
+        return self._receptor.process(packet)
+
+    def serve_forever(
+        self,
+        *,
+        on_receipt: Callable[[Receipt], None] | None = None,
+    ) -> None:
+        while True:
+            receipt = self.receive_once()
+            if on_receipt is not None:
+                on_receipt(receipt)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "binary-canticle-receptor"
+version = "0.1.0"
+description = "Bounded localhost UDP-cue receptor prototype"
+requires-python = ">=3.11"
+dependencies = ["cryptography>=45"]
+
+[tool.setuptools.packages.find]
+include = ["canticle_receptor*"]

--- a/tests/test_receptor.py
+++ b/tests/test_receptor.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from canticle_receptor import (
+    MAX_PACKET_SIZE,
+    AcceptReceipt,
+    IssuerPolicy,
+    Notice,
+    NoticeKind,
+    NoticeReceptor,
+    QuarantineReceipt,
+    ReceptorState,
+    RejectReceipt,
+    encode_signed_notice,
+)
+from canticle_receptor._publisher import PublisherUnavailable
+from canticle_receptor.model import (
+    QuarantineReason,
+    RejectReason,
+    VerifiedNotice,
+)
+
+NOW = 2_000_000_000
+SUBJECT = "sha256:" + ("a" * 64)
+
+
+class RecordingPublisher:
+    def __init__(self) -> None:
+        self.notices: list[VerifiedNotice] = []
+
+    def publish(self, notice: VerifiedNotice) -> None:
+        self.notices.append(notice)
+
+
+class UnavailablePublisher:
+    def publish(self, notice: VerifiedNotice) -> None:
+        del notice
+        raise PublisherUnavailable
+
+
+class ReceptorTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.state_path = Path(self.temporary_directory.name) / "state.sqlite3"
+        self.private_key = Ed25519PrivateKey.generate()
+        self.publisher = RecordingPublisher()
+        self.state = ReceptorState(self.state_path)
+        self.addCleanup(self.state.close)
+        self.receptor = self._receptor()
+
+    def _receptor(
+        self,
+        *,
+        quarantined: bool = False,
+        publisher: RecordingPublisher | UnavailablePublisher | None = None,
+        state: ReceptorState | None = None,
+    ) -> NoticeReceptor:
+        return NoticeReceptor(
+            issuers={
+                "issuer-a": IssuerPolicy(
+                    keys={"key-a": self.private_key.public_key()},
+                    quarantined=quarantined,
+                )
+            },
+            state=state or self.state,
+            publisher=publisher or self.publisher,
+            clock=lambda: NOW,
+        )
+
+    def _packet(
+        self,
+        *,
+        notice_id: str = "1" * 32,
+        kind: NoticeKind = NoticeKind.AVAILABLE,
+        subject: str = SUBJECT,
+        issued_at: int = NOW,
+        expires_at: int = NOW + 30,
+        private_key: Ed25519PrivateKey | None = None,
+        issuer: str = "issuer-a",
+        key_id: str = "key-a",
+    ) -> bytes:
+        return encode_signed_notice(
+            private_key or self.private_key,
+            issuer=issuer,
+            key_id=key_id,
+            notice=Notice(
+                kind=kind,
+                subject=subject,
+                notice_id=notice_id,
+                issued_at=issued_at,
+                expires_at=expires_at,
+            ),
+        )
+
+    def test_accepts_valid_notice_and_hands_verified_type_to_publisher(self) -> None:
+        receipt = self.receptor.process(self._packet())
+
+        self.assertIsInstance(receipt, AcceptReceipt)
+        self.assertEqual(len(self.publisher.notices), 1)
+        self.assertIsInstance(self.publisher.notices[0], VerifiedNotice)
+        self.assertEqual(self.publisher.notices[0].notice.kind, NoticeKind.AVAILABLE)
+
+    def test_encoding_is_deterministic(self) -> None:
+        first = self._packet(notice_id="c" * 32)
+        second = self._packet(notice_id="c" * 32)
+
+        self.assertEqual(first, second)
+
+    def test_rejects_invalid_signature_without_publishing(self) -> None:
+        receipt = self.receptor.process(
+            self._packet(private_key=Ed25519PrivateKey.generate())
+        )
+
+        self.assertEqual(receipt, RejectReceipt(RejectReason.INVALID_SIGNATURE))
+        self.assertEqual(self.publisher.notices, [])
+
+    def test_rejects_expired_and_excessive_ttl_notices(self) -> None:
+        expired = self.receptor.process(
+            self._packet(notice_id="2" * 32, issued_at=NOW - 30, expires_at=NOW)
+        )
+        excessive = self.receptor.process(
+            self._packet(notice_id="3" * 32, expires_at=NOW + 61)
+        )
+
+        self.assertEqual(expired, RejectReceipt(RejectReason.EXPIRED))
+        self.assertEqual(excessive, RejectReceipt(RejectReason.TTL_EXCEEDED))
+        self.assertEqual(self.publisher.notices, [])
+
+    def test_rejects_invalid_and_future_timestamp_windows(self) -> None:
+        invalid = self.receptor.process(
+            self._packet(
+                notice_id="d" * 32,
+                issued_at=NOW,
+                expires_at=NOW,
+            )
+        )
+        future = self.receptor.process(
+            self._packet(
+                notice_id="e" * 32,
+                issued_at=NOW + 6,
+                expires_at=NOW + 30,
+            )
+        )
+
+        self.assertEqual(invalid, RejectReceipt(RejectReason.INVALID_TIMESTAMP))
+        self.assertEqual(future, RejectReceipt(RejectReason.NOT_YET_VALID))
+        self.assertEqual(self.publisher.notices, [])
+
+    def test_rejects_replay(self) -> None:
+        packet = self._packet()
+
+        first = self.receptor.process(packet)
+        second = self.receptor.process(packet)
+
+        self.assertIsInstance(first, AcceptReceipt)
+        self.assertEqual(second, RejectReceipt(RejectReason.REPLAY))
+        self.assertEqual(len(self.publisher.notices), 1)
+
+    def test_tombstone_blocks_later_notice_for_subject(self) -> None:
+        tombstone = self.receptor.process(
+            self._packet(kind=NoticeKind.TOMBSTONE, notice_id="4" * 32)
+        )
+        later = self.receptor.process(self._packet(notice_id="5" * 32))
+
+        self.assertIsInstance(tombstone, AcceptReceipt)
+        self.assertEqual(later, RejectReceipt(RejectReason.SUBJECT_TOMBSTONED))
+        self.assertEqual(len(self.publisher.notices), 1)
+
+    def test_rejects_oversized_malformed_and_noncanonical_packets(self) -> None:
+        oversized = self.receptor.process(b"x" * (MAX_PACKET_SIZE + 1))
+        malformed = self.receptor.process(b"{")
+        canonical_packet = self._packet(notice_id="6" * 32)
+        noncanonical_value = json.loads(canonical_packet)
+        noncanonical = json.dumps(noncanonical_value, indent=1).encode()
+        noncanonical_receipt = self.receptor.process(noncanonical)
+
+        self.assertEqual(oversized, RejectReceipt(RejectReason.PACKET_TOO_LARGE))
+        self.assertEqual(malformed, RejectReceipt(RejectReason.MALFORMED_PACKET))
+        self.assertEqual(
+            noncanonical_receipt,
+            RejectReceipt(RejectReason.NON_CANONICAL_PACKET),
+        )
+        self.assertEqual(self.publisher.notices, [])
+
+    def test_closed_schema_rejects_payload_fields_without_echoing_them(self) -> None:
+        value = json.loads(self._packet(notice_id="7" * 32))
+        value["notice"]["payload"] = "forbidden-value"
+        packet = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+
+        receipt = self.receptor.process(packet)
+
+        self.assertIsInstance(receipt, RejectReceipt)
+        self.assertNotIn("forbidden", repr(receipt))
+        self.assertEqual(self.publisher.notices, [])
+
+    def test_quarantines_policy_blocked_unknown_issuer_and_unknown_key(self) -> None:
+        quarantined = self._receptor(quarantined=True).process(
+            self._packet(
+                notice_id="8" * 32,
+                private_key=Ed25519PrivateKey.generate(),
+            )
+        )
+        unknown = self.receptor.process(
+            self._packet(notice_id="9" * 32, issuer="issuer-b")
+        )
+        unknown_key = self.receptor.process(
+            self._packet(notice_id="f" * 32, key_id="key-b")
+        )
+
+        self.assertEqual(
+            quarantined,
+            QuarantineReceipt(QuarantineReason.ISSUER_QUARANTINED),
+        )
+        self.assertEqual(
+            unknown,
+            QuarantineReceipt(QuarantineReason.ISSUER_NOT_ALLOWED),
+        )
+        self.assertEqual(
+            unknown_key,
+            QuarantineReceipt(QuarantineReason.KEY_NOT_ALLOWED),
+        )
+        self.assertEqual(self.publisher.notices, [])
+
+    def test_quarantines_when_bounded_state_caches_are_full(self) -> None:
+        bounded_replay = ReceptorState(
+            Path(self.temporary_directory.name) / "bounded-replay.sqlite3",
+            max_replay_entries=1,
+        )
+        self.addCleanup(bounded_replay.close)
+        replay_receptor = self._receptor(state=bounded_replay)
+        replay_receptor.process(self._packet(notice_id="0" * 32))
+
+        replay_full = replay_receptor.process(
+            self._packet(
+                notice_id="1" * 31 + "0",
+                subject="sha256:" + ("b" * 64),
+            )
+        )
+
+        bounded_tombstones = ReceptorState(
+            Path(self.temporary_directory.name) / "bounded-tombstones.sqlite3",
+            max_tombstones=1,
+        )
+        self.addCleanup(bounded_tombstones.close)
+        tombstone_receptor = self._receptor(state=bounded_tombstones)
+        tombstone_receptor.process(
+            self._packet(
+                notice_id="2" * 31 + "0",
+                kind=NoticeKind.TOMBSTONE,
+            )
+        )
+        tombstone_full = tombstone_receptor.process(
+            self._packet(
+                notice_id="3" * 31 + "0",
+                kind=NoticeKind.TOMBSTONE,
+                subject="sha256:" + ("b" * 64),
+            )
+        )
+
+        self.assertEqual(
+            replay_full,
+            QuarantineReceipt(QuarantineReason.REPLAY_CACHE_FULL),
+        )
+        self.assertEqual(
+            tombstone_full,
+            QuarantineReceipt(QuarantineReason.TOMBSTONE_CACHE_FULL),
+        )
+
+    def test_quarantines_publisher_failure_without_retrying_claim(self) -> None:
+        packet = self._packet(notice_id="a" * 32)
+        unavailable = self._receptor(publisher=UnavailablePublisher())
+
+        first = unavailable.process(packet)
+        second = unavailable.process(packet)
+
+        self.assertEqual(
+            first,
+            QuarantineReceipt(QuarantineReason.PUBLISHER_UNAVAILABLE),
+        )
+        self.assertEqual(second, RejectReceipt(RejectReason.REPLAY))
+
+    def test_replay_dedup_survives_receptor_restart(self) -> None:
+        packet = self._packet(notice_id="b" * 32)
+        first = self.receptor.process(packet)
+        self.state.close()
+
+        restarted_state = ReceptorState(self.state_path)
+        self.addCleanup(restarted_state.close)
+        restarted = self._receptor(state=restarted_state)
+        second = restarted.process(packet)
+
+        self.assertIsInstance(first, AcceptReceipt)
+        self.assertEqual(second, RejectReceipt(RejectReason.REPLAY))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import socket
+import tempfile
+import unittest
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from canticle_receptor import (
+    AcceptReceipt,
+    IssuerPolicy,
+    Notice,
+    NoticeKind,
+    NoticeReceptor,
+    ReceptorState,
+    UdpCueListener,
+    encode_signed_notice,
+)
+from canticle_receptor.model import VerifiedNotice
+
+NOW = 2_000_000_000
+
+
+class RecordingPublisher:
+    def __init__(self) -> None:
+        self.notices: list[VerifiedNotice] = []
+
+    def publish(self, notice: VerifiedNotice) -> None:
+        self.notices.append(notice)
+
+
+class UdpListenerTest(unittest.TestCase):
+    def test_localhost_datagram_reaches_private_publisher_seam(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            key = Ed25519PrivateKey.generate()
+            publisher = RecordingPublisher()
+            state = ReceptorState(Path(directory) / "state.sqlite3")
+            self.addCleanup(state.close)
+            receptor = NoticeReceptor(
+                issuers={
+                    "issuer-a": IssuerPolicy(keys={"key-a": key.public_key()}),
+                },
+                state=state,
+                publisher=publisher,
+                clock=lambda: NOW,
+            )
+            packet = encode_signed_notice(
+                key,
+                issuer="issuer-a",
+                key_id="key-a",
+                notice=Notice(
+                    kind=NoticeKind.AVAILABLE,
+                    subject="sha256:" + ("c" * 64),
+                    notice_id="c" * 32,
+                    issued_at=NOW,
+                    expires_at=NOW + 30,
+                ),
+            )
+
+            with UdpCueListener(receptor, port=0) as listener:
+                with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sender:
+                    sender.sendto(packet, listener.address)
+                receipt = listener.receive_once(timeout=1)
+
+            self.assertIsInstance(receipt, AcceptReceipt)
+            self.assertEqual(len(publisher.notices), 1)
+
+    def test_listener_refuses_non_loopback_bind(self) -> None:
+        with self.assertRaisesRegex(ValueError, "listener_must_be_ipv4_loopback"):
+            UdpCueListener(object(), host="0.0.0.0")  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- adds the tested, localhost-only Binary Canticle UDP-cue receptor prototype
- records the evidence-backed Ringserver 4.5.4 verdict: no native UDP submission path; custom UDP cue is not SeedLink
- uses a closed, bounded, canonical Ed25519-signed notice envelope with issuer/key, TTL, replay, tombstone, and quarantine controls
- hands verified metadata only through a private `DataLinkPublisher` seam
- adds `.gitignore` so test-generated Python bytecode is not tracked

Closes #49.

## Verification

```text
python3 -m unittest discover -s tests -v  # 15 passed
python3 -m compileall -q canticle_receptor tests
git diff --check
```

## Explicit limits

This does not modify Ringserver, claim UDP is SeedLink, implement remote listening or artifact transport, or claim a native DataLink delivery proof. `PROTOTYPE-NOTES.md` gives the exact blocked follow-up proof requiring Ringserver plus DataLink writer/reader binaries.
